### PR TITLE
Documentation: fix typo in `git submodule ...` command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -140,7 +140,7 @@ tims inside the TAF file contained in Medal Of Honor Mission 1 Level 3*
 
 Before building make sure to fetch all the submodules by typing:  
 
-> git submodule --init --recursive  
+> git submodule update --init --recursive
 
 then type:  
 


### PR DESCRIPTION
A small misprint in the documentation: the correct command to fetch git submodules is `git submodule update --init --recursive`.